### PR TITLE
feat: Prevent duplicate product and material creation

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -24,6 +24,9 @@ class Product(models.Model):
     company = models.ForeignKey(Company, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
 
+    class Meta:
+        unique_together = ('company', 'name')
+
     def __str__(self):
         return self.name
 
@@ -34,6 +37,9 @@ class Material(models.Model):
     unit = models.CharField(max_length=50)
     quantity = models.DecimalField(max_digits=10, decimal_places=2)
     low_stock_threshold = models.DecimalField(max_digits=10, decimal_places=2, default=10.00)
+
+    class Meta:
+        unique_together = ('company', 'name')
 
     def __str__(self):
         return f"{self.name} ({self.quantity} {self.unit})"

--- a/api/tests.py
+++ b/api/tests.py
@@ -126,6 +126,28 @@ class CoreApiTests(APITestCase):
         self.assertIn('Low Stock Material', low_stock_names)
         self.assertNotIn('High Stock Material', low_stock_names)
 
+    def test_duplicate_product_creation_is_prevented(self):
+        """
+        Ensure that creating a product with a duplicate name within the same company fails.
+        """
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('product-list')
+        # This product name already exists from the CoreApiTests setUp
+        data = {'name': 'Test Product'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_duplicate_material_creation_is_prevented(self):
+        """
+        Ensure that creating a material with a duplicate name within the same company fails.
+        """
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('material-list')
+        # This material name already exists from the CoreApiTests setUp
+        data = {'name': 'Test Material', 'unit': 'kg', 'quantity': 10}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class UserManagementApiTests(APITestCase):
     def setUp(self):
@@ -223,6 +245,28 @@ class CalculatorApiTests(APITestCase):
         self.assertIsInstance(result['required_quantity'], float)
         self.assertIsInstance(result['current_stock'], float)
         self.assertIsInstance(result['shortfall'], float)
+
+    def test_product_with_same_name_in_different_company_succeeds(self):
+        """
+        Ensure a product with the same name as one in another company can be created.
+        """
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('product-list')
+        # This product name exists in the company created in CoreApiTests
+        data = {'name': 'Test Product'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_material_with_same_name_in_different_company_succeeds(self):
+        """
+        Ensure a material with the same name as one in another company can be created.
+        """
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('material-list')
+        # This material name exists in the company created in CoreApiTests
+        data = {'name': 'Test Material', 'unit': 'kg', 'quantity': 10}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_calculator_with_shortfall(self):
         """

--- a/api/views.py
+++ b/api/views.py
@@ -60,7 +60,11 @@ class ProductViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         if hasattr(self.request.user, 'profile'):
-            serializer.save(company=self.request.user.profile.company)
+            company = self.request.user.profile.company
+            name = serializer.validated_data.get('name')
+            if Product.objects.filter(company=company, name=name).exists():
+                raise serializers.ValidationError({'name': 'A product with this name already exists in your company.'})
+            serializer.save(company=company)
         else:
             raise serializers.ValidationError("Admin user cannot create company-specific resources.")
 
@@ -119,7 +123,11 @@ class MaterialViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         if hasattr(self.request.user, 'profile'):
-            serializer.save(company=self.request.user.profile.company)
+            company = self.request.user.profile.company
+            name = serializer.validated_data.get('name')
+            if Material.objects.filter(company=company, name=name).exists():
+                raise serializers.ValidationError({'name': 'A material with this name already exists in your company.'})
+            serializer.save(company=company)
         else:
             raise serializers.ValidationError("Admin user cannot create company-specific resources.")
 


### PR DESCRIPTION
This commit prevents the creation of products and materials with the same name within the same company.

- Adds a `unique_together` constraint to the `Product` and `Material` models for the `(company, name)` fields.
- Adds explicit validation in the `perform_create` methods of the `ProductViewSet` and `MaterialViewSet` to check for uniqueness before saving.
- Adds tests to verify that creating a duplicate product or material returns a 400 Bad Request error.
- Adds tests to verify that products and materials with the same name can be created in different companies.