### PR TITLE
fix(ui): Handle API errors correctly in snackbar

### DIFF
--- a/lib/providers/material_provider.dart
+++ b/lib/providers/material_provider.dart
@@ -62,6 +62,7 @@ class MaterialProvider with ChangeNotifier {
       notifyListeners();
     } catch (e) {
       print(e);
+      rethrow;
     }
   }
 

--- a/lib/providers/product_provider.dart
+++ b/lib/providers/product_provider.dart
@@ -50,6 +50,7 @@ class ProductProvider with ChangeNotifier {
       notifyListeners();
     } catch (e) {
       print(e);
+      rethrow;
     }
   }
 


### PR DESCRIPTION
This commit fixes an issue where a success message was shown in the snackbar even when the API call to create a product or material failed (e.g., when creating a duplicate).

- Modified `ProductProvider` and `MaterialProvider` to re-throw exceptions caught from the `ApiService`.
- This allows the UI layer (`ProductEditScreen` and `MaterialEditScreen`), which already has error handling logic, to catch the exceptions and display a proper error message in the snackbar.