### PR TITLE
fix: Roll back login flow to a stable state

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -49,17 +49,16 @@ class AuthProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<String?> login(String username, String password) async {
+  Future<void> login(String username, String password) async {
     _status = AuthStatus.Authenticating;
     notifyListeners();
     try {
       await apiService.login(username, password);
-      await _initAuth(); // This will set status to Authenticated and notify
-      return null; // Indicates success
+      await _initAuth();
     } catch (e) {
-      // On error, just return the error message. Do not change the state here.
-      // The UI will be responsible for telling the provider to change state.
-      return e.toString();
+      print('Login failed: $e'); // Log for developer
+      _status = AuthStatus.Unauthenticated;
+      notifyListeners();
     }
   }
 
@@ -80,8 +79,4 @@ class AuthProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  void setAuthStatus(AuthStatus status) {
-    _status = status;
-    notifyListeners();
-  }
 }

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -18,23 +18,8 @@ class _LoginScreenState extends State<LoginScreen> {
   Future<void> _submit() async {
     if (_formKey.currentState!.validate()) {
       _formKey.currentState!.save();
-      final authProvider = Provider.of<AuthProvider>(context, listen: false);
-      final errorMessage = await authProvider.login(_username, _password);
-
-      // If login fails, errorMessage will not be null.
-      if (errorMessage != null) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(errorMessage.replaceFirst('Exception: ', '')),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-          );
-          // After showing the message, reset the status to stop the loading indicator.
-          authProvider.setAuthStatus(AuthStatus.Unauthenticated);
-        }
-      }
-      // If login succeeds, errorMessage is null, and the AuthWrapper will navigate away.
+      // Fire and forget. The provider will handle state changes.
+      Provider.of<AuthProvider>(context, listen: false).login(_username, _password);
     }
   }
 


### PR DESCRIPTION
This commit reverts the login page functionality to a simple, stable state to address user reports of the app crashing or getting stuck on a failed login.

The new implementation ensures stability by handling all state changes within the `AuthProvider` and removing all error handling logic from the `LoginScreen`.

- `AuthProvider.login` is now a `Future<void>` method that catches all exceptions internally. On failure, it resets the authentication status to stop the loading spinner and prevent the app from getting stuck. It does not re-throw errors, preventing crashes.
- `LoginScreen._submit` is now a simple, fire-and-forget call to the provider.

This implementation prioritizes stability and preventing crashes, as requested by the user, at the expense of showing a specific error message on a failed login.